### PR TITLE
Functional default compilation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'http://rubygems.org'
 
+gemspec
+
 group :development, :test do
   gem 'rspec',      '~> 2.14.1'
   gem 'bundler'
@@ -8,8 +10,3 @@ group :development, :test do
   gem 'guard-rubocop'
   gem 'rubocop'
 end
-
-gem 'rake'
-gem 'liquid'
-gem 'rake-compiler'
-gem 'multi_json'

--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ Reactor uses the awesome [qmk_firmware](http://github.com/jackhumbert/qmk_firmwa
 - Take JSON input
 - Generate a .c template file based on the JSON and the liquid template. Name it something unique
 - Create a hex file by compiling that c file. Name it something unique too
-- read .hex file and return it
+- Read .hex file and return it
 
 # Local development
 
-You can run the tests with `be guard` - which will watch for changes in ruby files and run whenever they do
+You can run the tests with `be guard` - which will watch for changes in ruby files and run whenever they do.
+
+Testing is done in ruby 2.2.2
 
 ## Updating the firmware
 
@@ -72,7 +74,3 @@ Then run `make` for the default keymap, or
     
 for your own keymap. This requires a files keymap_yourown.c in the subfolder keymaps.
 You should end up with a `ergodox_ez.hex` file, which you can use with the [Teensy loader](http://www.pjrc.com/teensy/loader_cli.html) or [Teensy GUI](https://www.pjrc.com/teensy/loader.html)
-
-## License
-
-MIT, see LICENSE

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Reactor uses the awesome [qmk_firmware](http://github.com/jackhumbert/qmk_firmwa
 ## General process
 
 - Take JSON input
-- Generate a .c template file base on the JSON and the liquid template named for the type value in in the JSON
-- Return the .hex file created from running make with that file
+- Generate a .c template file based on the JSON and the liquid template. Name it something unique
+- Create a hex file by compiling that c file. Name it something unique too
+- read .hex file and return it
 
 # Local development
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,17 @@ Reactor uses the awesome [qmk_firmware](http://github.com/jackhumbert/qmk_firmwa
 
 ## General process
 
-- Initialize and set tmp directory if it's passed
 - Take JSON input
 - Generate a .c template file base on the JSON and the liquid template named for the type value in in the JSON
-- Return the .hex file created from running make with that file.
+- Return the .hex file created from running make with that file
+
+# Local development
+
+You can run the tests with `be guard` - which will watch for changes in ruby files and run whenever they do
 
 ## Updating the firmware
 
-The qmk_firmware is included in this repository as a git subtree. Any **changes to qmk_firmware should be made to the [qmk_firmware repository](http://github.com/jackhumbert/qmk_firmware)**. 
+The qmk_firmware is included in this repository as a git subtree. Any **changes to qmk_firmware should be made to the [qmk_firmware repository](http://github.com/jackhumbert/qmk_firmware)** not this repository.
 
 To update the subtree from the qmk_firmware repository, pull the updates from qmk_firmware into this repository.
 
@@ -39,9 +42,6 @@ To update the subtree from the qmk_firmware repository, pull the updates from qm
 2. Update the subtree
     
     `git subtree pull --prefix lib/firmware qmk_firmware master --squash`
-
-
-
 
 <sub>[Read more about git subtrees here](http://blogs.atlassian.com/2013/05/alternatives-to-git-submodule-git-subtree/)</sub>
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ To update the subtree from the qmk_firmware repository, pull the updates from qm
 
 #### Linux
 
-TBD
+Using the instructions from [the teensy loader build environment](https://www.pjrc.com/teensy/gcc.html):
+
+    sudo apt-get install gcc-avr binutils-avr avr-libc
 
 #### Mac OSX
 
@@ -70,10 +72,6 @@ Then run `make` for the default keymap, or
     
 for your own keymap. This requires a files keymap_yourown.c in the subfolder keymaps.
 You should end up with a `ergodox_ez.hex` file, which you can use with the [Teensy loader](http://www.pjrc.com/teensy/loader_cli.html) or [Teensy GUI](https://www.pjrc.com/teensy/loader.html)
-
-#### Windows
-
-TBD
 
 ## License
 

--- a/keyboard_reactor.gemspec
+++ b/keyboard_reactor.gemspec
@@ -3,16 +3,15 @@ require File.expand_path('../lib/keyboard_reactor/version', __FILE__)
 
 Gem::Specification.new do |gem|
   gem.version       = KeyboardReactor::VERSION
-  gem.authors       = ['Seth Herr']
+  gem.authors       = %w(sethherr tdegrunt)
   gem.description   = gem.summary = 'Keyboard firmware generator using qmk_firmware - from Fusion JSON'
   gem.homepage      = 'https://github.com/ErgoDox-EZ/reactor'
   gem.license       = 'MIT'
-  gem.executables   = ['keyboard_reactor']
-  gem.files         = `git ls-files README.md Rakefile LICENSE.md lib bin`.split("\n")
+  gem.files         = `git ls-files README.md Rakefile LICENSE.md lib`.split("\n")
   gem.name          = 'keyboard_reactor'
   gem.require_paths = ['lib']
   gem.add_dependency 'multi_json', '~> 1.11', '>= 1.11.2'
-  gem.add_dependency 'rake-compiler', '~> 0.9', '>= 0.9.5'
+  gem.add_dependency 'liquid', '~> 3.0', '>= 3.0.6'
   gem.add_development_dependency 'rake', '~> 10.4'
   gem.add_development_dependency 'rspec', '>= 3.3', '< 4.0'
 end

--- a/lib/keyboard_reactor/output.rb
+++ b/lib/keyboard_reactor/output.rb
@@ -52,8 +52,6 @@ module KeyboardReactor
     end
 
     def hex
-      return default_hex
-
       write_c_file
       # Override the default target with our ID so that we create unique files
       `cd #{firmware_path.to_s} && make clean && TARGET=#{id} make -e KEYMAP="#{id}"`

--- a/lib/keyboard_reactor/output.rb
+++ b/lib/keyboard_reactor/output.rb
@@ -1,12 +1,12 @@
 module KeyboardReactor
   class Output
-    def initialize(keyboard_json = nil, tmp_dir: nil, keyboard_hash: nil)
-      @tmp_dir = tmp_dir || self.class.relative_path('tmp')
+    def initialize(keyboard_json = nil, keyboard_hash: nil)
       @keyboard_hash = keyboard_hash || MultiJson.load(keyboard_json)
       @id = "#{(Time.now.to_f * 100).round}reactor"
     end
 
     attr_reader :tmp_dir, :keyboard_hash, :find_type, :id
+    attr_writer :keyboard_type
 
     def self.relative_path(path)
       File.expand_path(path, BASE_DIR)
@@ -25,16 +25,13 @@ module KeyboardReactor
     end
 
     def hex_file_path
-      self.class.relative_path("#{firmware_path}/#{@id}.hex")
-    end
-
-    def write_output(keyboard_json)
+      @hex_file_path ||= self.class.relative_path("#{firmware_path}/#{@id}.hex")
     end
 
     def keyboard_type
-      type = @keyboard_hash['type']
-      return type.to_s if self.class.known_types.include?(type)
-      fail "Unknown keyboard type '#{type}', not one of #{self.class.known_types}"
+      @keyboard_type ||= @keyboard_hash['type']
+      return @keyboard_type.to_s if self.class.known_types.include?(@keyboard_type)
+      fail "Unknown keyboard type '#{@keyboard_type}', not one of #{self.class.known_types}"
     end
 
     def layout_template
@@ -54,48 +51,34 @@ module KeyboardReactor
       File.write(c_file_path, c_file)
     end
 
-    def write_hex_file
+    def hex
+      return default_hex
+
       write_c_file
       # Override the default target with our ID so that we create unique files
       `cd #{firmware_path.to_s} && make clean && TARGET=#{id} make -e KEYMAP="#{id}"`
+      read_hex_file
     end
 
-    # post '/' do
-    #   layout = JSON.load(request.body.read)
-    #   type = layout['type']
+    def existing_compilations
+      Dir.chdir(firmware_path)
+      Dir[*(%w(eep elf lss map sym hex).map { |ext| "*.#{ext}" })] - ['reference_compiled_default_firmware.hex']
+    end
 
-    #   uuid = SecureRandom.uuid()
-    #   tpl = File.read("./templates/#{type}.liquid")
+    def delete_existing_compilations
+      existing_compilations.each { |f| File.delete(f) }
+    end
 
-    #   c_file = Liquid::Template.parse(tpl).render({'columns' => COLUMNS[type], 'layout' => layout})
+    def default_hex
+      @hex_file_path = "#{firmware_path}/#{keyboard_type}.hex"
+      `cd #{firmware_path.to_s} && make clean && make KEYMAP="default"`
+      read_hex_file
+    end
 
-    #   # TODO: Commenting these out, for now - makes testing faster, but will wreak havoc
-    #   # Also - cp is very slow
-    #   # `cp -r qmk_firmware /tmp/#{uuid}`
-    #   #output_file = "/tmp/#{uuid}/keyboard/#{type}/keymaps/keymap_#{uuid}.c"
-
-    #   output_file = "qmk_firmware/keyboard/#{type}/keymaps/keymap_#{uuid}.c"
-
-    #   f = File.new(output_file, 'w')
-    #   f.write(c_file)
-    #   f.close
-
-    #   `cd qmk_firmware/keyboard/#{type} && make KEYMAP="#{uuid}"`
-
-    #   status = 200
-
-    #   begin
-    #     hex = File.read("qmk_firmware/keyboard/#{type}/#{type}.hex")
-    #   rescue Errno::ENOENT
-    #     status = 400
-    #   end
-
-    #   headers = {
-    #       'Content-Disposition' => "attachment;filename=#{type}.hex",
-    #       'Content-Type' => 'application/octet-stream'
-    #   }
-
-    #   [status, headers, hex]
-    # end
+    def read_hex_file
+      File.read(hex_file_path)
+    rescue
+      fail "Unable to read generated hex file, #{hex_file_path}"
+    end
   end
 end

--- a/lib/keyboard_reactor/version.rb
+++ b/lib/keyboard_reactor/version.rb
@@ -1,3 +1,3 @@
 module KeyboardReactor
-  VERSION = '0.0.3'
+  VERSION = '0.0.4'
 end

--- a/lib/keyboard_reactor/version.rb
+++ b/lib/keyboard_reactor/version.rb
@@ -1,3 +1,3 @@
 module KeyboardReactor
-  VERSION = '0.0.1'
+  VERSION = '0.0.3'
 end

--- a/spec/keyboard_reactor/output_spec.rb
+++ b/spec/keyboard_reactor/output_spec.rb
@@ -72,10 +72,10 @@ describe KeyboardReactor::Output do
   end
 
   describe :hex do
-    it 'returns default hex, because things are broken' do
+    it 'compiles a new hexfile from ergodox json' do
       keyboard_reactor = KeyboardReactor::Output.new(ergodox_json)
-      expect(keyboard_reactor).to receive(:default_hex) { 'foo' }
-      expect(keyboard_reactor.hex).to eq('foo')
+      keyboard_reactor.hex
+      expect(File.exist?(keyboard_reactor.hex_file_path)).to be_true
     end
   end
 end

--- a/spec/keyboard_reactor/output_spec.rb
+++ b/spec/keyboard_reactor/output_spec.rb
@@ -1,34 +1,16 @@
 require 'spec_helper'
 
 describe KeyboardReactor::Output do
-  let(:ergodox_json) { File.read('spec/fixtures/ergodox_ez.json') }
+  let(:ergodox_json) do
+    File.read(File.expand_path('../fixtures/ergodox_ez.json', File.dirname(__FILE__)))
+  end
 
   describe :initialize do
-    context 'no passed path' do
-      it 'assigns the default tmp dir' do
-        keyboard_reactor = KeyboardReactor::Output.new(keyboard_hash: {})
-        expect(keyboard_reactor.tmp_dir).to eq(keyboard_reactor.class.relative_path('tmp'))
-      end
-    end
     context 'passed keyboard_json' do
       it 'parses the json' do
         keyboard_reactor = KeyboardReactor::Output.new(ergodox_json)
         expect(keyboard_reactor.keyboard_hash['layers'][0]['keymap'].count).to eq 84
       end
-    end
-    context 'passed tmp_dir' do
-      it 'assigns the passed tmp dir' do
-        path = File.dirname(__FILE__)
-        keyboard_reactor = KeyboardReactor::Output.new(tmp_dir: path, keyboard_hash: {})
-        expect(keyboard_reactor.tmp_dir).to eq(path)
-      end
-    end
-  end
-
-  describe :write_output do
-    it 'calls what it should call' do
-      keyboard_reactor = KeyboardReactor::Output.new(ergodox_json)
-      keyboard_reactor.write_hex_file
     end
   end
 
@@ -50,10 +32,50 @@ describe KeyboardReactor::Output do
     end
   end
 
+  describe 'read hex file' do
+    it "fails if a file isn't present" do
+      keyboard_reactor = KeyboardReactor::Output.new(keyboard_hash: { 'type' => 'ergodox_ez' })
+      keyboard_reactor.delete_existing_compilations
+      expect { keyboard_reactor.read_hex_file }.to raise_error
+    end
+  end
+
   describe 'c_file' do
     it 'returns the generated c file for ergodox_ez' do
       keyboard_reactor = KeyboardReactor::Output.new(ergodox_json)
       expect(keyboard_reactor.c_file).to_not be_nil
+    end
+  end
+
+  describe 'write_c_file' do
+    it 'writes a c file' do
+      keyboard_reactor = KeyboardReactor::Output.new(keyboard_hash: { 'type' => 'ergodox_ez' })
+      c_file = keyboard_reactor.c_file_path
+      expect(File.exist?(c_file)).to be_false
+      keyboard_reactor.write_c_file
+      expect(File.exist?(c_file)).to be_true
+    end
+  end
+
+  describe 'write default ergodox hex' do
+    # Because difficulties writing the layout file correctly,
+    # we're ensuring that we can correctly compile a hex file as a test
+    it 'writes the default hex file' do
+      keyboard_reactor = KeyboardReactor::Output.new(keyboard_hash: {})
+      keyboard_reactor.keyboard_type = 'ergodox_ez'
+      firmware_dir = keyboard_reactor.firmware_path
+      hex_file = "#{firmware_dir}/ergodox_ez.hex"
+      keyboard_reactor.delete_existing_compilations
+      keyboard_reactor.default_hex
+      expect(File.exist?(hex_file)).to be_true
+    end
+  end
+
+  describe :hex do
+    it 'returns default hex, because things are broken' do
+      keyboard_reactor = KeyboardReactor::Output.new(ergodox_json)
+      expect(keyboard_reactor).to receive(:default_hex) { 'foo' }
+      expect(keyboard_reactor.hex).to eq('foo')
     end
   end
 end


### PR DESCRIPTION
This compiles a file when you call `KeyboardReactor::Output.new.hex`

It compiles the default file, because of issues getting liquid to work and the fact that the JSON isn't stable in Fusion, so who knows what input it will be taking!?!

But it works! It successfully compiles and reads the hex file it creates!

It's published and on [rubygems](https://rubygems.org/gems/keyboard_reactor) @tdegrunt - if you tell me your email address I can add you as an owner of the gem.
